### PR TITLE
Remove Whitespace Around Photos

### DIFF
--- a/app/styles/partials/_flickr.scss
+++ b/app/styles/partials/_flickr.scss
@@ -22,7 +22,7 @@
 
 .flickr-container-row-photo-header {
 	padding: 0.5em;
-	margin-bottom: 0;
+	margin: 0;
 }
 
 .search-sorting-row {

--- a/app/styles/partials/_flickr.scss
+++ b/app/styles/partials/_flickr.scss
@@ -31,7 +31,7 @@
 	.search-sorting-row-input {
 		@extend .col-md-6;
 
-		margin-bottom: 2em;
+		margin-bottom: 1em;
 
 		input,
 		select {

--- a/app/styles/partials/_flickr.scss
+++ b/app/styles/partials/_flickr.scss
@@ -9,6 +9,8 @@
 .flickr-container-row-photo {
 	@extend .col-md-4, .col-sm-6, .col-xs-12;
 
+	margin-bottom: 2em;
+
 	header {
 		max-width: 500px;
 	}

--- a/app/styles/partials/_flickr.scss
+++ b/app/styles/partials/_flickr.scss
@@ -4,6 +4,8 @@
 
 .flickr-container-row {
 	@extend .row;
+
+	margin-top: 1em;
 }
 
 .flickr-container-row-photo {
@@ -26,8 +28,6 @@
 }
 
 .search-sorting-row {
-	margin-top: 1em;
-	
 	.search-sorting-row-input {
 		@extend .col-md-6;
 

--- a/app/styles/partials/_flickr.scss
+++ b/app/styles/partials/_flickr.scss
@@ -29,13 +29,11 @@
 	.search-sorting-row-input {
 		@extend .col-md-6;
 
+		margin-bottom: 2em;
+
 		input,
 		select {
 			@extend .form-control;
 		}
-	}
-
-	.search-input-row {
-		margin-bottom: 1em;	
 	}
 }

--- a/app/styles/partials/_layout.scss
+++ b/app/styles/partials/_layout.scss
@@ -1,5 +1,5 @@
 .body-container {
 	@extend .container;
 
-	padding-bottom: 2em;
+	padding-bottom: 1em;
 }

--- a/app/views/flickr.html
+++ b/app/views/flickr.html
@@ -2,7 +2,7 @@
 	<h2>Flickr Photos</h2>
 
 	<div class="flickr-container-row search-sorting-row">
-		<div class="search-sorting-row-input search-input-row">
+		<div class="search-sorting-row-input">
 			<input placeholder="Search by title" autofocus ng-model="query">
 		</div>
 		<div class="search-sorting-row-input">


### PR DESCRIPTION
- Remove margins in the h3 tags in order to control how much margins are needed for each photo.
- Fix spacing between the search and sorting as well as the row they are in so that space between them and the photos is the same distance like between the photos, on all screen sizes.
