### PR TITLE
Fix mirror changes

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -16,4 +16,4 @@ angular
     'ngRoute',
     'ngSanitize',
     'ngTouch'
-  ])
+  ]);

--- a/app/scripts/directives/flickr.js
+++ b/app/scripts/directives/flickr.js
@@ -9,7 +9,7 @@ var app = angular.module('fedexerciseApp');
  * # flickr
  */
 app
-  .controller('flickrCRTL', function($scope, flickrFactory) {
+  .controller('flickrCrtl', function($scope, flickrFactory) {
     flickrFactory.callFlickrFunctions('flickr.people.getPublicPhotos').success(function(data) {
       $scope.photos = data.photos.photo;
     });

--- a/app/scripts/services/flickrfactory.js
+++ b/app/scripts/services/flickrfactory.js
@@ -14,13 +14,20 @@ angular.module('fedexerciseApp')
     var baseURI = 'https://api.flickr.com/services/rest/';
     
     return {
-      callFlickrFunctions: function (flickrMethod) {
+      callFlickrFunctions: function (flickrMethod, flickrMethodArguments) {
+        var extraUrlMethodArguments = '';
+
+        for(var flickrMethodArgName in flickrMethodArguments) {
+          extraUrlMethodArguments += '&' + flickrMethodArgName + '=' + flickrMethodArguments[flickrMethodArgName];
+        }
+
         return $http.get(baseURI + 
           '?method=' + flickrMethod + 
           '&api_key=' + apiKey + 
           '&user_id=' + userId + 
           '&format=json' + 
-          '&nojsoncallback=1', { 
+          '&nojsoncallback=1' +
+          extraUrlMethodArguments, { 
             cache: true 
           });
       }

--- a/app/views/flickr.html
+++ b/app/views/flickr.html
@@ -1,4 +1,4 @@
-<section class="flickr-container" ng-controller="flickrCRTL as flickr">
+<section class="flickr-container" ng-controller="flickrCrtl as flickr">
 	<h2>Flickr Photos</h2>
 
 	<div class="flickr-container-row search-sorting-row">

--- a/test/spec/directives/flickr.js
+++ b/test/spec/directives/flickr.js
@@ -5,16 +5,9 @@ describe('Directive: flickr', function () {
   // load the directive's module
   beforeEach(module('fedexerciseApp'));
 
-  var element,
-    scope;
+  var scope;
 
   beforeEach(inject(function ($rootScope) {
     scope = $rootScope.$new();
-  }));
-
-  it('should make hidden element visible', inject(function ($compile) {
-    element = angular.element('<flickr></flickr>');
-    element = $compile(element)(scope);
-    expect(element.text()).toBe('this is the flickr directive');
   }));
 });

--- a/test/spec/services/flickrfactory.js
+++ b/test/spec/services/flickrfactory.js
@@ -23,7 +23,7 @@ describe('Service: flickrFactory', function () {
     httpBackend.verifyNoOutstandingExpectation();
     httpBackend.verifyNoOutstandingRequest();
 
-    flickrFunctionToTest = "";
+    flickrFunctionToTest = '';
   });
 
   it('should return 200 and response with list of photos', function() {
@@ -33,24 +33,24 @@ describe('Service: flickrFactory', function () {
         page: 1,
         pages: 1,
         perpage: 100,
-        total: "12",
+        total: '12',
         photo: [
           {
-            id: "17936160485",
-            owner: "132365033@N08",
-            server: "7738",
+            id: '17936160485',
+            owner: '132365033@N08',
+            server: '7738',
             farm: 8,
-            title: "rhino",
+            title: 'rhino',
             ispublic: 1,
             isfriend: 0,
             isfamily: 0
           },
           {
-            id: "17936788061",
-            owner: "132365033@N08",
-            server: "7761",
+            id: '17936788061',
+            owner: '132365033@N08',
+            server: '7761',
             farm: 8,
-            title: "gharial",
+            title: 'gharial',
             ispublic: 1,
             isfriend: 0,
             isfamily: 0
@@ -59,7 +59,7 @@ describe('Service: flickrFactory', function () {
       }
     };
 
-    flickrFunctionToTest = "flickr.people.getPublicPhotos";
+    flickrFunctionToTest = 'flickr.people.getPublicPhotos';
 
     // expectGET to make sure this is called once.
     httpBackend.expectGET('https://api.flickr.com/services/rest/' + 
@@ -80,7 +80,7 @@ describe('Service: flickrFactory', function () {
       result = response.data;
     });
     
-    // flush the backend to "execute" the request to do the expectedGET assertion.
+    // flush the backend to 'execute' the request to do the expectedGET assertion.
     httpBackend.flush();
     
     // check the result. 


### PR DESCRIPTION
For the final pull request for the exercise made the necessary changes before submitting it. 

Here are the following chances:
- Add Optional Arguments for the callFlickrFunciton function because of Flickr functions may use other arguments in order to use them.
- Fix minor JavaScript formating in app.js and flickrfactory.js.
- Fix AngularJS naming convention for the Flickr controller name to have capillarization of Crtl
- Remove directive Flickr test to similar to Flickr Factory testing
